### PR TITLE
PATH_INFO bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,9 @@ RUN cmake . && make -j4 && make install
 RUN rm -f /etc/httpd/conf.d/welcome.conf /etc/httpd/conf.modules.d/00-systemd.conf
 
 # Manually copy some files I couldn't figure out with the CMake system
+### PATH_INFO bug:  comment out this line and rebuild the Docker image
+###   to disable mod_ruby and show the correct implementation of path_info
+###   in Passenger/Sinatra
 RUN cp -a config/mod_ruby.conf /etc/httpd/conf.modules.d/
 
 # librhtml.so
@@ -84,7 +87,9 @@ COPY docker/*.cgi /var/www/cgi-bin/
 COPY docker/httpd.conf /etc/httpd/conf/httpd.conf
 COPY docker/gdb.input /gdb.input
 COPY docker/httpd-gdb /httpd-gdb
-COPY docker/sinatra /
+COPY docker/sinatra /sinatra
+
+RUN cd /sinatra && bundle install --system
 
 # Force apache logs to docker console logs
 RUN ln -sf /dev/console /var/log/httpd/access_log \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN yum -y upgrade && yum install -y \
   gpg \
   httpd \
   httpd-devel \
+  libcurl-devel \
   libffi-devel \
   libtool \
   libyaml \
@@ -52,7 +53,11 @@ SHELL ["/bin/bash", "-l", "-c"]
 RUN rvm requirements
 
 # Pick your ruby version here
-RUN rvm install ruby-2.3.3
+RUN rvm install ruby-2.5.8 
+
+RUN gem install bundler -v 1.17.3 \
+  && gem install passenger -v 6.0.4 \
+  && passenger-install-apache2-module -a
 
 # Setup our libruby.so dir in ld.so.conf
 RUN rvm config-get libdir > /etc/ld.so.conf.d/ruby.conf && ldconfig
@@ -79,6 +84,7 @@ COPY docker/*.cgi /var/www/cgi-bin/
 COPY docker/httpd.conf /etc/httpd/conf/httpd.conf
 COPY docker/gdb.input /gdb.input
 COPY docker/httpd-gdb /httpd-gdb
+COPY docker/sinatra /
 
 # Force apache logs to docker console logs
 RUN ln -sf /dev/console /var/log/httpd/access_log \

--- a/docker/httpd.conf
+++ b/docker/httpd.conf
@@ -17,28 +17,11 @@ DocumentRoot "/var/www/html"
 </Directory>
 MaxClients 1
 CoreDumpDirectory /tmp
-#RubyHandlerDeclare TEST
-#RubyHandlerModule  TEST "/var/www/html/test.rb"
-#RubyHandlerClass   TEST Test::Handler
-#RubyHandlerMethod  TEST handle
-
-# Define a handler to be used as an access checker
-#RubyHandlerDeclare ACCESS_TEST
-#RubyHandlerModule  ACCESS_TEST "/var/www/html/access_test.rb"
-#RubyHandlerClass   ACCESS_TEST AccessTest::Handler
-#RubyHandlerMethod  ACCESS_TEST check_access
 
 <Directory "/var/www/html">
     Options Indexes FollowSymLinks
     AllowOverride None
     Require all granted
-    # An access handler runs before other handlers and doesn't
-    # alter the request unless access is denied
-    #RubyAccessHandler ACCESS_TEST
-
-    # Comment out these two lines to see index.html contents
-    #SetHandler ruby-handler
-    #RubyHandler TEST
 </Directory>
 
 <IfModule dir_module>
@@ -60,22 +43,6 @@ LogLevel warn
     </IfModule>
     CustomLog "logs/access_log" combined
 </IfModule>
-
-<IfModule alias_module>
-    ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
-    ScriptAlias /deep/directory/cgi-bin/ "/var/www/cgi-bin/"
-</IfModule>
-
-<Location "/deep/directory/cgi-bin">
-</Location>
-<Directory "/var/www/cgi-bin">
-    AllowOverride None
-    Options None
-    Require all granted
-    #AcceptPathInfo On
-    # CGI apps will see $REMOTE_USER set
-    #RubyAccessHandler ACCESS_TEST
-</Directory>
 
 <IfModule mime_module>
     TypesConfig /etc/mime.types
@@ -99,6 +66,7 @@ LoadModule passenger_module /usr/local/rvm/gems/ruby-2.5.8/gems/passenger-6.0.4/
 <IfModule mod_passenger.c>
   PassengerRoot /usr/local/rvm/gems/ruby-2.5.8/gems/passenger-6.0.4
   PassengerDefaultRuby /usr/local/rvm/gems/ruby-2.5.8/wrappers/ruby
+  PassengerLogFile /var/log/httpd/error_log
 </IfModule>
 
 <VirtualHost *:80>

--- a/docker/httpd.conf
+++ b/docker/httpd.conf
@@ -17,16 +17,16 @@ DocumentRoot "/var/www/html"
 </Directory>
 MaxClients 1
 CoreDumpDirectory /tmp
-RubyHandlerDeclare TEST
-RubyHandlerModule  TEST "/var/www/html/test.rb"
-RubyHandlerClass   TEST Test::Handler
-RubyHandlerMethod  TEST handle
+#RubyHandlerDeclare TEST
+#RubyHandlerModule  TEST "/var/www/html/test.rb"
+#RubyHandlerClass   TEST Test::Handler
+#RubyHandlerMethod  TEST handle
 
 # Define a handler to be used as an access checker
-RubyHandlerDeclare ACCESS_TEST
-RubyHandlerModule  ACCESS_TEST "/var/www/html/access_test.rb"
-RubyHandlerClass   ACCESS_TEST AccessTest::Handler
-RubyHandlerMethod  ACCESS_TEST check_access
+#RubyHandlerDeclare ACCESS_TEST
+#RubyHandlerModule  ACCESS_TEST "/var/www/html/access_test.rb"
+#RubyHandlerClass   ACCESS_TEST AccessTest::Handler
+#RubyHandlerMethod  ACCESS_TEST check_access
 
 <Directory "/var/www/html">
     Options Indexes FollowSymLinks
@@ -34,11 +34,11 @@ RubyHandlerMethod  ACCESS_TEST check_access
     Require all granted
     # An access handler runs before other handlers and doesn't
     # alter the request unless access is denied
-    RubyAccessHandler ACCESS_TEST
+    #RubyAccessHandler ACCESS_TEST
 
     # Comment out these two lines to see index.html contents
-    SetHandler ruby-handler
-    RubyHandler TEST
+    #SetHandler ruby-handler
+    #RubyHandler TEST
 </Directory>
 
 <IfModule dir_module>
@@ -63,14 +63,18 @@ LogLevel warn
 
 <IfModule alias_module>
     ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+    ScriptAlias /deep/directory/cgi-bin/ "/var/www/cgi-bin/"
 </IfModule>
 
+<Location "/deep/directory/cgi-bin">
+</Location>
 <Directory "/var/www/cgi-bin">
     AllowOverride None
     Options None
     Require all granted
+    #AcceptPathInfo On
     # CGI apps will see $REMOTE_USER set
-    RubyAccessHandler ACCESS_TEST
+    #RubyAccessHandler ACCESS_TEST
 </Directory>
 
 <IfModule mime_module>
@@ -90,3 +94,16 @@ AddDefaultCharset UTF-8
 EnableSendfile on
 
 IncludeOptional conf.d/*.conf
+
+LoadModule passenger_module /usr/local/rvm/gems/ruby-2.5.8/gems/passenger-6.0.4/buildout/apache2/mod_passenger.so
+<IfModule mod_passenger.c>
+  PassengerRoot /usr/local/rvm/gems/ruby-2.5.8/gems/passenger-6.0.4
+  PassengerDefaultRuby /usr/local/rvm/gems/ruby-2.5.8/wrappers/ruby
+</IfModule>
+
+<VirtualHost *:80>
+  ServerName sinatra
+  RailsEnv development
+  PassengerEnabled on
+  PassengerAppRoot /sinatra
+</VirtualHost>

--- a/docker/sinatra/Gemfile
+++ b/docker/sinatra/Gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gem 'rake'
+
+gem 'sinatra', require: 'sinatra'

--- a/docker/sinatra/config.ru
+++ b/docker/sinatra/config.ru
@@ -1,0 +1,3 @@
+require File.absolute_path("server.rb")
+
+run App

--- a/docker/sinatra/server.rb
+++ b/docker/sinatra/server.rb
@@ -1,0 +1,7 @@
+require 'sinatra/base'
+
+class App < Sinatra::Base
+  get '/*' do
+    ENV.inspect
+  end
+end

--- a/docker/sinatra/server.rb
+++ b/docker/sinatra/server.rb
@@ -1,7 +1,12 @@
 require 'sinatra/base'
 
 class App < Sinatra::Base
-  get '/*' do
-    ENV.inspect
+  get '*' do
+    <<~STR
+      SCRIPT_NAME: #{ENV['SCRIPT_NAME']}
+      PATH_INFO: #{ENV['PATH_INFO']}
+      REQUEST_URI: #{ENV['REQUEST_URI']}
+      sinatra request.path_info: #{request.path_info}
+    STR
   end
 end

--- a/docker/test.cgi
+++ b/docker/test.cgi
@@ -3,5 +3,4 @@ echo Content-Type: text/plain
 echo
 
 echo "--- test.cgi ---"
-echo "REMOTE_USER: $REMOTE_USER"
-
+set

--- a/script/docker_run
+++ b/script/docker_run
@@ -2,15 +2,15 @@
 root=$( readlink -f $( dirname $( readlink -f $0 ) )/.. )
 
 docker rm -f mod_ruby_run_container
+#  -v $root:/usr/src/mod_ruby \
 # Change 8080 here if you have a local conflict with it
 docker run \
   --name=mod_ruby_run_container \
   --cap-add=SYS_PTRACE \
   --security-opt seccomp=unconfined \
-  -v $root:/usr/src/mod_ruby \
   -ti \
   -p 8080:80 \
-  mod_ruby /bin/bash -l -c 'cmake . && make install && /httpd-gdb'
+  mod_ruby /bin/bash -l -c '/httpd-gdb'
 #If you run httpd in FOREGROUND and run the container
 #with -d instead of -ti
 #docker logs -f mod_ruby_run_container


### PR DESCRIPTION
This recreates the bug in #8.

1) Build/Run the image:

```
$ ./script/docker_build && ./script/docker_run 
```

2) Check a deep path using the `sinatra` vhost:

```
$ curl -H "Host: sinatra" localhost:8080/one/two/three
SCRIPT_NAME: /one
PATH_INFO: /two/three
REQUEST_URI: /one/two/three
sinatra request.path_info: /two/three
```

3)  Also note how the CGI vars seem to persist globally across multiple requests, and are not altered for each request:

```
$ curl -H "Host: sinatra" localhost:8080/four/five/six
SCRIPT_NAME: /one
PATH_INFO: /two/three
REQUEST_URI: /one/two/three
sinatra request.path_info: /five/six
```

4)  Comment out Dockerfile line 79 to disable mod_ruby and recreate the test:

```
$ curl -H "Host: sinatra" localhost:8080/one/two/three
SCRIPT_NAME: 
PATH_INFO: 
REQUEST_URI: 
sinatra request.path_info: /one/two/three

$ curl -H "Host: sinatra" localhost:8080/four/five/six
SCRIPT_NAME: 
PATH_INFO: 
REQUEST_URI: 
sinatra request.path_info: /four/five/six
```
