### PR TITLE
CentOS 7 EOL change to use Vault

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,39 @@
 FROM centos:centos7
 
-RUN yum install -y epel-release && yum -y upgrade && yum install -y \
-  apr-devel \
-  apr-util \
-  apr-util-devel \
-  autoconf \
-  automake \
-  bison \
-  bzip2 \
-  cmake3 \
-  curl \
-  cyrus-sasl \
-  cyrus-sasl-devel \
-  flex \
-  flex-devel \
-  gcc \
-  gcc-c++ \
-  gdb \
-  git \
-  gpg \
-  httpd \
-  httpd-devel \
-  libffi-devel \
-  libtool \
-  libyaml \
-  openssl-devel \
-  patch \
-  readline-devel \
-  sqlite-devel \
-  make \
-  redhat-lsb \
-  unzip \
-  zlib-devel 
+RUN sed -i 's|^mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/CentOS-Base.repo \
+  && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Base.repo \
+  && yum install -y epel-release && yum -y upgrade && yum install -y \
+    apr-devel \
+    apr-util \
+    apr-util-devel \
+    autoconf \
+    automake \
+    bison \
+    bzip2 \
+    cmake3 \
+    curl \
+    cyrus-sasl \
+    cyrus-sasl-devel \
+    flex \
+    flex-devel \
+    gcc \
+    gcc-c++ \
+    gdb \
+    git \
+    gpg \
+    httpd \
+    httpd-devel \
+    libffi-devel \
+    libtool \
+    libyaml \
+    openssl-devel \
+    patch \
+    readline-devel \
+    sqlite-devel \
+    make \
+    redhat-lsb \
+    unzip \
+    zlib-devel 
 
 # Import GPG key for RVM
 RUN gpg \

--- a/script/docker_run
+++ b/script/docker_run
@@ -10,7 +10,7 @@ docker run \
   -v $root:/usr/src/mod_ruby \
   -ti \
   -p 8080:80 \
-  mod_ruby /bin/bash -l -c 'cmake3 . && make install && /httpd-gdb'
+  mod_ruby 
 #If you run httpd in FOREGROUND and run the container
 #with -d instead of -ti
 #docker logs -f mod_ruby_run_container


### PR DESCRIPTION
C7 is EOL'd now and we need to use vault.centos.org in the Docker image build.

Note:  I'll be following up later with an Oracle Linux 8 upgrade.  This is just to get the current state of the project building to compare with, as it's currently busted.